### PR TITLE
Changed login behaviour

### DIFF
--- a/backend/market-platform/src/models.rs
+++ b/backend/market-platform/src/models.rs
@@ -11,7 +11,7 @@ pub struct User {
     pub pass_hash: String,
     pub credit: f64,
     // pub created_at: DateTime<Utc>,
-    pub active: bool,
+    // pub active: bool,
 }
 
 #[derive(Insertable)]

--- a/backend/market-platform/src/user_management/mod.rs
+++ b/backend/market-platform/src/user_management/mod.rs
@@ -219,21 +219,12 @@ pub fn login(credentials: Json<Credentials>) -> Value {
 
     match users
         .filter(email.eq(credentials.email.clone()))
+        .filter(active.eq(true))
         .select(User::as_select())
         .first(connection)
     {
         Ok(user) => {
             if bcrypt::verify(credentials.password.clone(), &*user.pass_hash) {
-                if !user.active {
-                    match diesel::update(users)
-                        .filter(user_id.eq(user.user_id))
-                        .set(active.eq(true))
-                        .execute(connection)
-                    {
-                        Ok(_) => {}
-                        Err(_) => {}
-                    }
-                }
                 let claim = Claims::from_name(user.user_id.to_string());
                 match claim.into_token() {
                     Ok(token) => {


### PR DESCRIPTION
Changed the behaviour of the login endpoint to remove a bug where agents logging in would undo users deactivating their accounts.

This means that account removal is now permanent and will not try to reactivate the user's account if they try to login again within a certain grace period.